### PR TITLE
steps_per_epoch should be int otherwise it fails

### DIFF
--- a/CIFAR10_Keras_GPU.ipynb
+++ b/CIFAR10_Keras_GPU.ipynb
@@ -469,7 +469,7 @@
     "start = time()\n",
     "history = model.fit_generator(\n",
     "    train_gen(batch_size), epochs=25, \n",
-    "    steps_per_epoch=np.ceil(x_train.shape[0]/batch_size),\n",
+    "    steps_per_epoch=np.ceil(x_train.shape[0]/batch_size).astype(int) ,\n",
     "    validation_data = (x_val, y_val),\n",
     ")\n",
     "end = time()"


### PR DESCRIPTION
fixing TypeError: 'numpy.float64' object cannot be interpreted as an integer